### PR TITLE
Render alternative image and headline in home page

### DIFF
--- a/lib/quintype/api/story.rb
+++ b/lib/quintype/api/story.rb
@@ -76,15 +76,28 @@ class API
       @cards = story['cards'] || []
     end
 
-    def to_h(config={})
+    def to_h(config={}, page_type=nil)
       hash = story.merge({
         'url' => URL.story(story),
-        'canonical_url' => URL.story_canonical(config['root_url'], story),
         'time_in_minutes' => time_in_minutes,
         'tags' => add_urls_to_tags
       })
       if config.present?
-        hash.merge!({ 'sections' => add_display_names_to_sections(config) })
+        hash.merge!({
+          'sections' => add_display_names_to_sections(config),
+          'canonical_url' => URL.story_canonical(config['root_url'], story),
+        })
+      end
+      if story['alternative'].present? && page_type
+        alternative_props = story['alternative'][page_type]['default']
+        if alternative_props.present?
+          hash.merge!('headline' => (alternative_props['headline'].presence || story['headline']))
+          if alternative_props['hero_image'].present?
+            hash.merge!('hero_image_s3_key' => (alternative_props['hero_image']['hero_image_s3_key'].presence || story['hero_image_s3_key']),
+                      'hero_image_metadata' => (alternative_props['hero_image']['hero_image_metadata'].presence || story['hero_image_metadata']),
+                      'hero_image_caption' => (alternative_props['hero_image']['hero_image_caption'].presence || story['hero_image_caption']))
+          end
+        end
       end
       hash
     end

--- a/lib/quintype/api/story.rb
+++ b/lib/quintype/api/story.rb
@@ -93,9 +93,9 @@ class API
         if alternative_props.present?
           hash.merge!('headline' => (alternative_props['headline'].presence || story['headline']))
           if alternative_props['hero_image'].present?
-            hash.merge!('hero_image_s3_key' => (alternative_props['hero_image']['hero_image_s3_key'].presence || story['hero_image_s3_key']),
-                      'hero_image_metadata' => (alternative_props['hero_image']['hero_image_metadata'].presence || story['hero_image_metadata']),
-                      'hero_image_caption' => (alternative_props['hero_image']['hero_image_caption'].presence || story['hero_image_caption']))
+            hash.merge!('hero_image_s3_key' => (alternative_props['hero_image']['hero_image_s3_key']),
+                      'hero_image_metadata' => (alternative_props['hero_image']['hero_image_metadata']),
+                      'hero_image_caption' => (alternative_props['hero_image']['hero_image_caption']))
           end
         end
       end

--- a/spec/api/story_spec.rb
+++ b/spec/api/story_spec.rb
@@ -88,7 +88,7 @@ describe API::Story do
       config = API.config
       stories = described_class.where({limit: 1})
       story = stories.first.story
-      serialized_story = stories.first.to_h(config)
+      serialized_story = stories.first.to_h(config.merge('root_url' => 'http://something.com'))
 
       expect(story['sections'].first.keys).to_not include("display_name")
       expect(story['sections'].first).to eq({"id"=>5, "name"=>"India"})
@@ -97,6 +97,18 @@ describe API::Story do
       expect(serialized_story['tags'].first.keys).to include("url")
       expect(serialized_story['sections'].first).to eq({"id"=>5, "name"=>"India", "display_name"=>"India"})
       expect(serialized_story['tags'].first).to eq({"id"=>1821, "name"=>"Afzal Guru", "url"=>"/topic/Afzal%20Guru"})
+    end
+
+    it 'serializes alternate information correctly', :vcr => { cassette_name: "api_story_alternative"} do
+      config = API.config
+      stories = described_class.where({limit: 1})
+      story = stories.first.story
+      serialized_story = stories.first.to_h(config.merge('root_url' => 'http://something.com'), 'home')
+
+      expect(serialized_story['headline']).to eq 'alternative headline'
+      expect(serialized_story['hero_image_s3_key']).to eq 'local_thequint/2016-04/ea79ecf5-d6de-44b7-8cbc-357bbab64d94/BOqr2ncH_bigger.png'
+      expect(serialized_story['hero_image_metadata']).to eq ({"width"=>73, "height"=>73, "mime_type"=>"image/png", "focus_point"=>[34, 44]})
+      expect(serialized_story['hero_image_caption']).to eq 'hey this is the alternative image caption'
     end
   end
 end


### PR DESCRIPTION
This directly renders the alternative headline, hero image instead of default headline and hero image in the story map that is rendered in home page
