### PR TITLE
returns nil if API get response status is 400 or more

### DIFF
--- a/lib/quintype/api.rb
+++ b/lib/quintype/api.rb
@@ -199,6 +199,8 @@ class API
 
     def _get(url_path, *args)
       response = @@conn.get(@@api_base + url_path, *args)
+      return nil if response.status >= 400
+
       if response.body.present?
         body = JSON.parse(response.body)
 


### PR DESCRIPTION
This PR needs to be merged, for error responses to `API.config` in rails app to not be cached - https://github.com/quintype/southlive/commit/e9a8a6265e17d3475727f43fa7dd384ffc06e9dc
